### PR TITLE
Cleanup random selection function

### DIFF
--- a/C101_KinbakuClub/Slaves/Script.js
+++ b/C101_KinbakuClub/Slaves/Script.js
@@ -29,14 +29,6 @@ var C101_KinbakuClub_Slaves_PlayerNotVeryArousedGagged = false; // combined arou
 var C101_KinbakuClub_Slaves_PlayerVeryArousedGagged = false; // combined arousal and gag variables.
 var C101_KinbakuClub_Slaves_TeaseImage = 0; // image used for Jenna's hand is no special images.
 var C101_KinbakuClub_Slaves_Random = 0; // used for random numbers other than for responses.
-var C101_KinbakuClub_Slaves_Random1 = 0; // Random number scores for available responses.
-var C101_KinbakuClub_Slaves_Random2 = 0;
-var C101_KinbakuClub_Slaves_Random3 = 0;
-var C101_KinbakuClub_Slaves_Random4 = 0;
-var C101_KinbakuClub_Slaves_Random5 = 0;
-var C101_KinbakuClub_Slaves_Random6 = 0;
-var C101_KinbakuClub_Slaves_Random7 = 0;
-var C101_KinbakuClub_Slaves_Random8 = 0;
 var C101_KinbakuClub_Slaves_Option1 = false; // For selecting available responses.
 var C101_KinbakuClub_Slaves_Option2 = false;
 var C101_KinbakuClub_Slaves_Option3 = false;
@@ -499,40 +491,27 @@ function C101_KinbakuClub_Slaves_EndGame() {
 
 // Chapter 101 - Slaves - Select a random choice of the vairiable options during the game.
 function C101_KinbakuClub_Slaves_RandomSelection() {
-	C101_KinbakuClub_Slaves_Random1 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Random2 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Random3 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Random4 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Random5 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Random6 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Random7 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Random8 = Math.floor((Math.random() * 12) + 1);
-	C101_KinbakuClub_Slaves_Option1 = false;
-	C101_KinbakuClub_Slaves_Option2 = false;
-	C101_KinbakuClub_Slaves_Option3 = false;
-	C101_KinbakuClub_Slaves_Option4 = false;
-	C101_KinbakuClub_Slaves_Option5 = false;
-	C101_KinbakuClub_Slaves_Option6 = false;
-	C101_KinbakuClub_Slaves_Option7 = false;
-	C101_KinbakuClub_Slaves_Option8 = false;
-	C101_KinbakuClub_Slaves_Option9 = false;
-	C101_KinbakuClub_Slaves_Option10 = false;
-	C101_KinbakuClub_Slaves_Option11 = false;
-	C101_KinbakuClub_Slaves_Option12 = false;
-	if (C101_KinbakuClub_Slaves_PlayerArousal < 500) {
-		if ((C101_KinbakuClub_Slaves_Random1 == 1) || (C101_KinbakuClub_Slaves_Random2 == 1) || (C101_KinbakuClub_Slaves_Random3 == 1) || (C101_KinbakuClub_Slaves_Random4 == 1) || (C101_KinbakuClub_Slaves_Random5 == 1) || (C101_KinbakuClub_Slaves_Random6 == 1) || (C101_KinbakuClub_Slaves_Random7 == 1) || (C101_KinbakuClub_Slaves_Random8 == 1)) C101_KinbakuClub_Slaves_Option1 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 2) || (C101_KinbakuClub_Slaves_Random2 == 2) || (C101_KinbakuClub_Slaves_Random3 == 2) || (C101_KinbakuClub_Slaves_Random4 == 2) || (C101_KinbakuClub_Slaves_Random5 == 2) || (C101_KinbakuClub_Slaves_Random6 == 2) || (C101_KinbakuClub_Slaves_Random7 == 2) || (C101_KinbakuClub_Slaves_Random8 == 2)) C101_KinbakuClub_Slaves_Option2 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 3) || (C101_KinbakuClub_Slaves_Random2 == 3) || (C101_KinbakuClub_Slaves_Random3 == 3) || (C101_KinbakuClub_Slaves_Random4 == 3) || (C101_KinbakuClub_Slaves_Random5 == 3) || (C101_KinbakuClub_Slaves_Random6 == 3) || (C101_KinbakuClub_Slaves_Random7 == 3) || (C101_KinbakuClub_Slaves_Random8 == 3)) C101_KinbakuClub_Slaves_Option3 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 4) || (C101_KinbakuClub_Slaves_Random2 == 4) || (C101_KinbakuClub_Slaves_Random3 == 4) || (C101_KinbakuClub_Slaves_Random4 == 4) || (C101_KinbakuClub_Slaves_Random5 == 4) || (C101_KinbakuClub_Slaves_Random6 == 4) || (C101_KinbakuClub_Slaves_Random7 == 4) || (C101_KinbakuClub_Slaves_Random8 == 4)) C101_KinbakuClub_Slaves_Option4 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 5) || (C101_KinbakuClub_Slaves_Random2 == 5) || (C101_KinbakuClub_Slaves_Random3 == 5) || (C101_KinbakuClub_Slaves_Random4 == 5) || (C101_KinbakuClub_Slaves_Random5 == 5) || (C101_KinbakuClub_Slaves_Random6 == 5) || (C101_KinbakuClub_Slaves_Random7 == 5) || (C101_KinbakuClub_Slaves_Random8 == 5)) C101_KinbakuClub_Slaves_Option5 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 6) || (C101_KinbakuClub_Slaves_Random2 == 6) || (C101_KinbakuClub_Slaves_Random3 == 6) || (C101_KinbakuClub_Slaves_Random4 == 6) || (C101_KinbakuClub_Slaves_Random5 == 6) || (C101_KinbakuClub_Slaves_Random6 == 6) || (C101_KinbakuClub_Slaves_Random7 == 6) || (C101_KinbakuClub_Slaves_Random8 == 6)) C101_KinbakuClub_Slaves_Option6 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 7) || (C101_KinbakuClub_Slaves_Random2 == 7) || (C101_KinbakuClub_Slaves_Random3 == 7) || (C101_KinbakuClub_Slaves_Random4 == 7) || (C101_KinbakuClub_Slaves_Random5 == 7) || (C101_KinbakuClub_Slaves_Random6 == 7) || (C101_KinbakuClub_Slaves_Random7 == 7) || (C101_KinbakuClub_Slaves_Random8 == 7)) C101_KinbakuClub_Slaves_Option7 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 8) || (C101_KinbakuClub_Slaves_Random2 == 8) || (C101_KinbakuClub_Slaves_Random3 == 8) || (C101_KinbakuClub_Slaves_Random4 == 8) || (C101_KinbakuClub_Slaves_Random5 == 8) || (C101_KinbakuClub_Slaves_Random6 == 8) || (C101_KinbakuClub_Slaves_Random7 == 8) || (C101_KinbakuClub_Slaves_Random8 == 8)) C101_KinbakuClub_Slaves_Option8 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 9) || (C101_KinbakuClub_Slaves_Random2 == 9) || (C101_KinbakuClub_Slaves_Random3 == 9) || (C101_KinbakuClub_Slaves_Random4 == 9) || (C101_KinbakuClub_Slaves_Random5 == 9) || (C101_KinbakuClub_Slaves_Random6 == 9) || (C101_KinbakuClub_Slaves_Random7 == 9) || (C101_KinbakuClub_Slaves_Random8 == 9)) C101_KinbakuClub_Slaves_Option9 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 10) || (C101_KinbakuClub_Slaves_Random2 == 10) || (C101_KinbakuClub_Slaves_Random3 == 10) || (C101_KinbakuClub_Slaves_Random4 == 10) || (C101_KinbakuClub_Slaves_Random5 == 10) || (C101_KinbakuClub_Slaves_Random6 == 10) || (C101_KinbakuClub_Slaves_Random7 == 10) || (C101_KinbakuClub_Slaves_Random8 == 10)) C101_KinbakuClub_Slaves_Option10 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 11) || (C101_KinbakuClub_Slaves_Random2 == 11) || (C101_KinbakuClub_Slaves_Random3 == 11) || (C101_KinbakuClub_Slaves_Random4 == 11) || (C101_KinbakuClub_Slaves_Random5 == 11) || (C101_KinbakuClub_Slaves_Random6 == 11) || (C101_KinbakuClub_Slaves_Random7 == 11) || (C101_KinbakuClub_Slaves_Random8 == 11)) C101_KinbakuClub_Slaves_Option11 = true;
-		if ((C101_KinbakuClub_Slaves_Random1 == 12) || (C101_KinbakuClub_Slaves_Random2 == 12) || (C101_KinbakuClub_Slaves_Random3 == 12) || (C101_KinbakuClub_Slaves_Random4 == 12) || (C101_KinbakuClub_Slaves_Random5 == 12) || (C101_KinbakuClub_Slaves_Random6 == 12) || (C101_KinbakuClub_Slaves_Random7 == 12) || (C101_KinbakuClub_Slaves_Random8 == 12)) C101_KinbakuClub_Slaves_Option12 = true;
+	// Select 8 random numbers, each between 1 and 12
+	var randomNumbers = []
+	for (var i = 0; i < 8; i++) {
+		randomNumbers.push(Math.floor((Math.random() * 12) + 1));
 	}
+	
+	var active = C101_KinbakuClub_Slaves_PlayerArousal < 500;
+	
+	C101_KinbakuClub_Slaves_Option1 = active && randomNumbers.includes(1) ? true : false;
+	C101_KinbakuClub_Slaves_Option2 = active && randomNumbers.includes(2) ? true : false;
+	C101_KinbakuClub_Slaves_Option3 = active && randomNumbers.includes(3) ? true : false;
+	C101_KinbakuClub_Slaves_Option4 = active && randomNumbers.includes(4) ? true : false;
+	C101_KinbakuClub_Slaves_Option5 = active && randomNumbers.includes(5) ? true : false;
+	C101_KinbakuClub_Slaves_Option6 = active && randomNumbers.includes(6) ? true : false;
+	C101_KinbakuClub_Slaves_Option7 = active && randomNumbers.includes(7) ? true : false;
+	C101_KinbakuClub_Slaves_Option8 = active && randomNumbers.includes(8) ? true : false;
+	C101_KinbakuClub_Slaves_Option9 = active && randomNumbers.includes(9) ? true : false;
+	C101_KinbakuClub_Slaves_Option10 = active && randomNumbers.includes(10) ? true : false;
+	C101_KinbakuClub_Slaves_Option11 = active && randomNumbers.includes(11) ? true : false;
+	C101_KinbakuClub_Slaves_Option12 = active && randomNumbers.includes(12) ? true : false;
+	
 	C101_KinbakuClub_Slaves_TextDisplay()
 	C101_KinbakuClub_Slaves_CalcParams();
 }


### PR DESCRIPTION
This still uses the previous random number selection method, it's just been cleaned up to make it more readable and to avoid duplication.

As far as I could tell, there was no reason for the `C101_KinbakuClub_Slaves_Random#` variables to be global. So that's been incorperated into the function to keep things cleaner.

--------------

I wouldn't normally go in and suggest changes to existing code like this, but the previous method was pretty chaotic and I thought having a method like this implemented somewhere might make it easier if you want to use a similar feature sometime in the future.

Note: I haven't actually tested this on a live game. I only tested the function on jsbin.